### PR TITLE
Update argparse default argument format

### DIFF
--- a/flake8_pytest_style/plugin.py
+++ b/flake8_pytest_style/plugin.py
@@ -50,7 +50,7 @@ class PytestStylePlugin(Plugin[Config]):
             parse_from_config=True,
             default=not DEFAULT_CONFIG.fixture_parentheses,
             help='Omit parentheses for @pytest.fixture decorators'
-            ' without parameters. (Default: %default)',
+            ' without parameters. (Default: %(default)s)',
         )
         option_manager.add_option(
             '--pytest-raises-require-match-for',
@@ -58,7 +58,7 @@ class PytestStylePlugin(Plugin[Config]):
             parse_from_config=True,
             default=DEFAULT_CONFIG.raises_require_match_for,
             help='List of exceptions for which flake8-pytest-style requires'
-            ' a match= argument in pytest.raises(). (Default: %default)',
+            ' a match= argument in pytest.raises(). (Default: %(default)s)',
         )
         option_manager.add_option(
             '--pytest-parametrize-names-type',
@@ -66,7 +66,7 @@ class PytestStylePlugin(Plugin[Config]):
             parse_from_config=True,
             default=DEFAULT_CONFIG.parametrize_names_type.value,
             help='Preferred type for multiple parameter names in'
-            ' @pytest.mark.parametrize. (Default: %default)',
+            ' @pytest.mark.parametrize. (Default: %(default)s)',
         )
         option_manager.add_option(
             '--pytest-parametrize-values-type',
@@ -74,7 +74,7 @@ class PytestStylePlugin(Plugin[Config]):
             parse_from_config=True,
             default=DEFAULT_CONFIG.parametrize_values_type.value,
             help='Preferred type for values in @pytest.mark.parametrize.'
-            ' (Default: %default)',
+            ' (Default: %(default)s)',
         )
         option_manager.add_option(
             '--pytest-parametrize-values-row-type',
@@ -82,7 +82,7 @@ class PytestStylePlugin(Plugin[Config]):
             parse_from_config=True,
             default=DEFAULT_CONFIG.parametrize_values_row_type.value,
             help='Preferred type for each row in @pytest.mark.parametrize'
-            ' in case of multiple parameters. (Default: %default)',
+            ' in case of multiple parameters. (Default: %(default)s)',
         )
         option_manager.add_option(
             '--pytest-mark-no-parentheses',
@@ -90,7 +90,7 @@ class PytestStylePlugin(Plugin[Config]):
             parse_from_config=True,
             default=not DEFAULT_CONFIG.mark_parentheses,
             help='Omit parentheses for @pytest.mark.foo decorators'
-            ' without parameters. (Default: %default)',
+            ' without parameters. (Default: %(default)s)',
         )
 
     @classmethod


### PR DESCRIPTION
Hi! 

Thanks for creating this, I've only recently discovered it, but have adopted it all over the place - it's great!

I just enabled flake8 logging for something unrelated and found some warning logs related to this plugin. I just thought I would let you know 🙂 

These are the errors:

```
flake8.options.manager    MainProcess    245 WARNING  option --pytest-fixture-no-parentheses: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
flake8.options.manager    MainProcess    245 WARNING  option --pytest-raises-require-match-for: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
flake8.options.manager    MainProcess    245 WARNING  option --pytest-parametrize-names-type: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
flake8.options.manager    MainProcess    245 WARNING  option --pytest-parametrize-values-type: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
flake8.options.manager    MainProcess    245 WARNING  option --pytest-parametrize-values-row-type: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
flake8.options.manager    MainProcess    245 WARNING  option --pytest-mark-no-parentheses: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
```

I've not really taken the time to check flake8 changelogs/code for more info.

If you wish to replicate, just run flake8 with `-v` 🙂 