### PR TITLE
Fix PT023 not checking @pytest.marks in classes

### DIFF
--- a/flake8_pytest_style/visitors/marks.py
+++ b/flake8_pytest_style/visitors/marks.py
@@ -48,4 +48,9 @@ class MarksVisitor(Visitor[Config]):
             self._check_mark_decorator(mark_decorator)
 
     visit_AsyncFunctionDef = visit_FunctionDef  # noqa: N815
-    visit_ClassDef = visit_FunctionDef  # noqa: N815
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.visit_FunctionDef(node)
+
+        # recurse into classes
+        self.generic_visit(node)

--- a/tests/test_PT023_incorrect_mark_parentheses_style.py
+++ b/tests/test_PT023_incorrect_mark_parentheses_style.py
@@ -125,7 +125,7 @@ SAMPLES_WITH_PARENTHESES = [
 
 
 @pytest.mark.parametrize('mark_parentheses', [True, False])
-def test_ok_with_parameters_no_matter_of_config(mark_parentheses: bool):
+def test_ok_with_parameters_regardless_of_config(mark_parentheses: bool):
     code = """
         import pytest
 

--- a/tests/test_PT023_incorrect_mark_parentheses_style.py
+++ b/tests/test_PT023_incorrect_mark_parentheses_style.py
@@ -1,22 +1,131 @@
+import pytest
 from flake8_plugin_utils import assert_error, assert_not_error
 
 from flake8_pytest_style.config import DEFAULT_CONFIG
 from flake8_pytest_style.errors import IncorrectMarkParenthesesStyle
 from flake8_pytest_style.visitors import MarksVisitor
 
+SAMPLES_WITHOUT_PARENTHESES = [
+    pytest.param(
+        """
+            import pytest
 
-def test_ok_no_parameters():
-    code = """
-        import pytest
+            @pytest.mark.foo
+            def test_something():
+                pass
+        """,
+        id='function',
+    ),
+    pytest.param(
+        """
+            import pytest
 
-        @pytest.mark.foo()
-        def test_something():
-            pass
-    """
-    assert_not_error(MarksVisitor, code, config=DEFAULT_CONFIG)
+            @pytest.mark.foo
+            class TestClass:
+                def test_something():
+                    pass
+        """,
+        id='class',
+    ),
+    pytest.param(
+        """
+            import pytest
+
+            class TestClass:
+                @pytest.mark.foo
+                def test_something():
+                    pass
+        """,
+        id='method',
+    ),
+    pytest.param(
+        """
+            import pytest
+
+            class TestClass:
+                @pytest.mark.foo
+                class TestNestedClass:
+                    def test_something():
+                        pass
+        """,
+        id='nested_class',
+    ),
+    pytest.param(
+        """
+            import pytest
+
+            class TestClass:
+                class TestNestedClass:
+                    @pytest.mark.foo
+                    def test_something():
+                        pass
+        """,
+        id='nested_class_method',
+    ),
+]
+
+SAMPLES_WITH_PARENTHESES = [
+    pytest.param(
+        """
+            import pytest
+
+            @pytest.mark.foo()
+            def test_something():
+                pass
+        """,
+        id='function',
+    ),
+    pytest.param(
+        """
+            import pytest
+
+            @pytest.mark.foo()
+            class TestClass:
+                def test_something():
+                    pass
+        """,
+        id='class',
+    ),
+    pytest.param(
+        """
+            import pytest
+
+            class TestClass:
+                @pytest.mark.foo()
+                def test_something():
+                    pass
+        """,
+        id='method',
+    ),
+    pytest.param(
+        """
+            import pytest
+
+            class TestClass:
+                @pytest.mark.foo()
+                class TestNestedClass:
+                    def test_something():
+                        pass
+        """,
+        id='nested_class',
+    ),
+    pytest.param(
+        """
+            import pytest
+
+            class TestClass:
+                class TestNestedClass:
+                    @pytest.mark.foo()
+                    def test_something():
+                        pass
+        """,
+        id='nested_class_method',
+    ),
+]
 
 
-def test_ok_with_parameters():
+@pytest.mark.parametrize('mark_parentheses', [True, False])
+def test_ok_with_parameters_no_matter_of_config(mark_parentheses: bool):
     code = """
         import pytest
 
@@ -24,54 +133,23 @@ def test_ok_with_parameters():
         def test_something():
             pass
     """
-    assert_not_error(MarksVisitor, code, config=DEFAULT_CONFIG)
+    config = DEFAULT_CONFIG._replace(mark_parentheses=mark_parentheses)
+    assert_not_error(MarksVisitor, code, config=config)
 
 
-def test_ok_without_parens():
-    code = """
-        import pytest
-
-        @pytest.mark.foo
-        def test_something():
-            pass
-    """
+@pytest.mark.parametrize('code', SAMPLES_WITHOUT_PARENTHESES)
+def test_ok_without_parens(code: str):
     config = DEFAULT_CONFIG._replace(mark_parentheses=False)
     assert_not_error(MarksVisitor, code, config=config)
 
 
-def test_ok_class():
-    code = """
-        import pytest
-
-        @pytest.mark.foo()
-        class TestClass:
-            def test_something():
-                pass
-    """
+@pytest.mark.parametrize('code', SAMPLES_WITH_PARENTHESES)
+def test_ok_with_parens(code: str):
     assert_not_error(MarksVisitor, code, config=DEFAULT_CONFIG)
 
 
-def test_ok_class_without_parens():
-    code = """
-        import pytest
-
-        @pytest.mark.foo
-        class TestClass:
-            def test_something():
-                pass
-    """
-    config = DEFAULT_CONFIG._replace(mark_parentheses=False)
-    assert_not_error(MarksVisitor, code, config=config)
-
-
-def test_error_without_parens():
-    code = """
-        import pytest
-
-        @pytest.mark.foo
-        def test_something():
-            pass
-    """
+@pytest.mark.parametrize('code', SAMPLES_WITHOUT_PARENTHESES)
+def test_error_without_parens(code: str):
     assert_error(
         MarksVisitor,
         code,
@@ -83,55 +161,8 @@ def test_error_without_parens():
     )
 
 
-def test_error_with_parens():
-    code = """
-        import pytest
-
-        @pytest.mark.foo()
-        def test_something():
-            pass
-    """
-    config = DEFAULT_CONFIG._replace(mark_parentheses=False)
-    assert_error(
-        MarksVisitor,
-        code,
-        IncorrectMarkParenthesesStyle,
-        config=config,
-        mark_name='foo',
-        expected_parens='',
-        actual_parens='()',
-    )
-
-
-def test_error_class_without_parens():
-    code = """
-        import pytest
-
-        @pytest.mark.foo
-        class TestClass:
-            def test_something():
-                pass
-    """
-    assert_error(
-        MarksVisitor,
-        code,
-        IncorrectMarkParenthesesStyle,
-        config=DEFAULT_CONFIG,
-        mark_name='foo',
-        expected_parens='()',
-        actual_parens='',
-    )
-
-
-def test_error_class_with_parens():
-    code = """
-        import pytest
-
-        @pytest.mark.foo()
-        class TestClass:
-            def test_something():
-                pass
-    """
+@pytest.mark.parametrize('code', SAMPLES_WITH_PARENTHESES)
+def test_error_with_parens(code: str):
     config = DEFAULT_CONFIG._replace(mark_parentheses=False)
     assert_error(
         MarksVisitor,


### PR DESCRIPTION
PT023 didn't check `@pytest.mark.foo` decorators in classes:

```python
class TestClass:
    @pytest.mark.foo()  # ok
    def test_something():
        pass

    @pytest.mark.foo  # also ok but should be an error
    def test_something_else():
        pass
```

Not it will recurse into classes and checks decorators on methods and nested classes.

I've also refactored tests for this rule because of DRY. Diff may look confusing. If it doesn't feel appropriate, please, let me know and I'll rewrite the tests.