### PR TITLE
Clarify options to solve PT011

### DIFF
--- a/flake8_pytest_style/errors.py
+++ b/flake8_pytest_style/errors.py
@@ -55,7 +55,7 @@ class RaisesWithoutException(Error):
 
 class RaisesWithoutMatch(Error):
     code = 'PT011'
-    message = 'set the match parameter in pytest.raises({exception})'
+    message = 'specify a narrower exception or set the match parameter in pytest.raises({exception})'
 
 
 class RaisesWithMultipleStatements(Error):


### PR DESCRIPTION
Clarify that the developer has two options to solve PT011.
The previous error message didn't make clear, that it's possible to solve PT011 by specifying a narrower exception type.