### PR TITLE
Add py.typed file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ MIT
 **Unreleased**
 
 * require at least Python 3.6.2
+* expose `py.typed` file
 
 **1.5.1 - 2021-11-05**
 


### PR DESCRIPTION
Closes #153 

By default, poetry adds py.typed files into wheel and source distributables. I manually verified that this happens. 