### PR TITLE
Handle unittest `assertRaises` assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Currently the following errors are reported:
 | [PT024] | pytest.mark.asyncio is unnecessary for fixtures |
 | [PT025] | pytest.mark.usefixtures has no effect on fixtures |
 | [PT026] | useless pytest.mark.usefixtures without parameters | 
+| [PT027] | use pytest.raises() instead of unittest-style '{assertion}' |
 
 ## Installation
 
@@ -230,3 +231,4 @@ MIT
 [PT024]: /docs/rules/PT024.md
 [PT025]: /docs/rules/PT025.md
 [PT026]: /docs/rules/PT026.md
+[PT027]: /docs/rules/PT027.md

--- a/docs/rules/PT027.md
+++ b/docs/rules/PT027.md
@@ -1,0 +1,32 @@
+# PT027
+
+`use pytest.raises() instead of unittest-style '{assertion}'`
+
+## Examples
+
+Bad code:
+
+```python
+import unittest
+
+class TestFoo(unittest.TestCase):
+    def test_foo(self):
+        with self.assertRaises(ValueError):
+            raise ValueError('foo')
+```
+
+Good code:
+
+```python
+import pytest
+import unittest
+
+class TestFoo(unittest.TestCase):
+    def test_foo(self):
+        with pytest.raises(ValueError):
+            raise ValueError('foo')
+```
+
+## Rationale
+
+* to make use of pytest's assertion rewriting

--- a/flake8_pytest_style/errors.py
+++ b/flake8_pytest_style/errors.py
@@ -143,3 +143,8 @@ class ErroneousUseFixturesOnFixture(Error):
 class UseFixturesWithoutParameters(Error):
     code = 'PT026'
     message = 'useless pytest.mark.usefixtures without parameters'
+
+
+class UnittestRaisesAssertion(Error):
+    code = 'PT027'
+    message = "use pytest.raises() instead of unittest-style '{assertion}'"

--- a/flake8_pytest_style/visitors/assertion.py
+++ b/flake8_pytest_style/visitors/assertion.py
@@ -3,7 +3,7 @@ import ast
 from flake8_plugin_utils import Visitor
 
 from flake8_pytest_style.config import Config
-from flake8_pytest_style.errors import CompositeAssertion, UnittestAssertion
+from flake8_pytest_style.errors import CompositeAssertion, UnittestAssertion, UnittestRaisesAssertion
 
 _UNITTEST_ASSERT_NAMES = (
     'assertAlmostEqual',
@@ -32,23 +32,26 @@ _UNITTEST_ASSERT_NAMES = (
     'assertNotIn',
     'assertNotIsInstance',
     'assertNotRegexpMatches',
-    'assertRaises',
-    'assertRaisesMessage',
-    'assertRaisesRegexp',
     'assertRegexpMatches',
     'assertSetEqual',
     'assertTrue',
     'assert_',
 )
 
+_UNITTEST_ASSERT_RAISES_NAMES = (
+    'assertRaises',
+    'assertRaisesMessage',
+    'assertRaisesRegexp',
+)
+
 
 class UnittestAssertionVisitor(Visitor[Config]):
     def visit_Call(self, node: ast.Call) -> None:
-        if (
-            isinstance(node.func, ast.Attribute)
-            and node.func.attr in _UNITTEST_ASSERT_NAMES
-        ):
-            self.error_from_node(UnittestAssertion, node, assertion=node.func.attr)
+        if isinstance(node.func, ast.Attribute):
+            if node.func.attr in _UNITTEST_ASSERT_NAMES:
+                self.error_from_node(UnittestAssertion, node, assertion=node.func.attr)
+            elif node.func.attr in _UNITTEST_ASSERT_RAISES_NAMES:
+                self.error_from_node(UnittestRaisesAssertion, node, assertion=node.func.attr)
 
 
 class AssertionVisitor(Visitor[Config]):

--- a/flake8_pytest_style/visitors/assertion.py
+++ b/flake8_pytest_style/visitors/assertion.py
@@ -3,7 +3,11 @@ import ast
 from flake8_plugin_utils import Visitor
 
 from flake8_pytest_style.config import Config
-from flake8_pytest_style.errors import CompositeAssertion, UnittestAssertion, UnittestRaisesAssertion
+from flake8_pytest_style.errors import (
+    CompositeAssertion,
+    UnittestAssertion,
+    UnittestRaisesAssertion,
+)
 
 _UNITTEST_ASSERT_NAMES = (
     'assertAlmostEqual',
@@ -51,7 +55,9 @@ class UnittestAssertionVisitor(Visitor[Config]):
             if node.func.attr in _UNITTEST_ASSERT_NAMES:
                 self.error_from_node(UnittestAssertion, node, assertion=node.func.attr)
             elif node.func.attr in _UNITTEST_ASSERT_RAISES_NAMES:
-                self.error_from_node(UnittestRaisesAssertion, node, assertion=node.func.attr)
+                self.error_from_node(
+                    UnittestRaisesAssertion, node, assertion=node.func.attr
+                )
 
 
 class AssertionVisitor(Visitor[Config]):

--- a/tests/test_PT027_unittest_raises_assertion.py
+++ b/tests/test_PT027_unittest_raises_assertion.py
@@ -1,0 +1,31 @@
+from flake8_plugin_utils import assert_error, assert_not_error
+
+from flake8_pytest_style.errors import UnittestRaisesAssertion
+from flake8_pytest_style.visitors import UnittestAssertionVisitor
+
+
+def test_ok_no_parameters():
+    code = """
+        import pytest
+
+        def test_xxx():
+            with pytest.raises(ValueError):
+                raise ValueError()
+    """
+    assert_not_error(UnittestAssertionVisitor, code)
+
+
+def test_error():
+    code = """
+        import pytest
+
+        def test_xxx():
+            with self.assertRaises(ValueError):
+                raise ValueError()
+    """
+    assert_error(
+        UnittestAssertionVisitor,
+        code,
+        UnittestRaisesAssertion,
+        assertion="assertRaises",
+    )


### PR DESCRIPTION
Added new rule to handle unittest `assertRaises` rewrites.

Fixes #214