### PR TITLE
Do not use upper bounds for dependencies versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 PT = 'flake8_pytest_style.plugin:PytestStylePlugin'
 
 [tool.poetry.dependencies]
-python = "^3.7.2"
-flake8-plugin-utils = "^1.3.2"
+python = ">=3.7"
+flake8-plugin-utils = ">=1.3.0"
 
 [tool.poetry.group.dev.dependencies]
 black = {version = "^23.3"}


### PR DESCRIPTION
It is considered a bad practice to add upper bounds to dependencies for libraries (not to be confused with applications).

Further reading: https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special