### PR TITLE
Invert defaults for `pytest-fixture-no-parentheses` and `pytest-mark-no-parentheses`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ MIT
 
 **Unreleased**
 
+* **BREAKING:** invert default values for `pytest-fixture-no-parentheses` and `pytest-mark-no-parentheses`
+  to conform with `pytest` official style
+  * If you get a lot of [PT001] or [PT023] violations after upgrading, consider setting explicit values
+    for these configuration options
 * require at least Python 3.8.1
 * support Python 3.12
 

--- a/docs/rules/PT001.md
+++ b/docs/rules/PT001.md
@@ -1,25 +1,25 @@
 # PT001
 
-`use @pytest.fixture() over @pytest.fixture`
+`use @pytest.fixture over @pytest.fixture()`
 
 ## Configuration
 
 * `pytest-fixture-no-parentheses`  
 Boolean flag specifying whether `@pytest.fixture()` without parameters
 should have parentheses.  
-If the option is set to false (the default), `@pytest.fixture()` is valid
-and `@pytest.fixture` is an error.  
-If set to true, `@pytest.fixture` is valid and `@pytest.fixture()` is
+If the option is set to true (the default), `@pytest.fixture` is valid
+and `@pytest.fixture()` is an error.  
+If set to false, `@pytest.fixture()` is valid and `@pytest.fixture` is
 an error.
 
 ## Examples
 
-Bad code (assuming `pytest-fixture-no-parentheses` set to false):
+Bad code (assuming `pytest-fixture-no-parentheses` set to true):
 
 ```python
 import pytest
 
-@pytest.fixture
+@pytest.fixture()
 def my_fixture():
     ...
 ```
@@ -29,7 +29,7 @@ Good code:
 ```python
 import pytest
 
-@pytest.fixture()
+@pytest.fixture
 def my_fixture():
     ...
 ```

--- a/docs/rules/PT023.md
+++ b/docs/rules/PT023.md
@@ -1,25 +1,25 @@
 # PT023
 
-`use @pytest.mark.foo() over @pytest.mark.foo`
+`use @pytest.mark.foo over @pytest.mark.foo()`
 
 ## Configuration
 
 * `pytest-mark-no-parentheses`  
 Boolean flag specifying whether `@pytest.mark.foo()` without parameters
 should have parentheses.  
-If the option is set to false (the default), `@pytest.mark.foo()` is valid
-and `@pytest.mark.foo` is an error.  
-If set to true, `@pytest.mark.foo` is valid and `@pytest.mark.foo()` is
+If the option is set to true (the default), `@pytest.mark.foo` is valid
+and `@pytest.mark.foo()` is an error.  
+If set to false, `@pytest.mark.foo()` is valid and `@pytest.mark.foo` is
 an error.
 
 ## Examples
 
-Bad code (assuming `pytest-mark-no-parentheses` set to false):
+Bad code (assuming `pytest-mark-no-parentheses` set to true):
 
 ```python
 import pytest
 
-@pytest.mark.foo
+@pytest.mark.foo()
 def test_something():
     ...
 ```
@@ -29,7 +29,7 @@ Good code:
 ```python
 import pytest
 
-@pytest.mark.foo()
+@pytest.mark.foo
 def test_something():
     ...
 ```

--- a/flake8_pytest_style/config.py
+++ b/flake8_pytest_style/config.py
@@ -32,7 +32,7 @@ class Config(NamedTuple):
 
 
 DEFAULT_CONFIG = Config(
-    fixture_parentheses=True,
+    fixture_parentheses=False,
     raises_require_match_for=[
         'BaseException',
         'Exception',
@@ -45,5 +45,5 @@ DEFAULT_CONFIG = Config(
     parametrize_names_type=ParametrizeNamesType.TUPLE,
     parametrize_values_type=ParametrizeValuesType.LIST,
     parametrize_values_row_type=ParametrizeValuesRowType.TUPLE,
-    mark_parentheses=True,
+    mark_parentheses=False,
 )

--- a/tests/test_PT001_incorrect_fixture_parentheses_style.py
+++ b/tests/test_PT001_incorrect_fixture_parentheses_style.py
@@ -4,7 +4,6 @@ from flake8_pytest_style.config import DEFAULT_CONFIG
 from flake8_pytest_style.errors import IncorrectFixtureParenthesesStyle
 from flake8_pytest_style.visitors import FixturesVisitor
 
-
 # make the configs independent of the actual default
 _CONFIG_WITHOUT_PARENS = DEFAULT_CONFIG._replace(fixture_parentheses=False)
 _CONFIG_WITH_PARENS = DEFAULT_CONFIG._replace(fixture_parentheses=True)

--- a/tests/test_PT001_incorrect_fixture_parentheses_style.py
+++ b/tests/test_PT001_incorrect_fixture_parentheses_style.py
@@ -5,6 +5,11 @@ from flake8_pytest_style.errors import IncorrectFixtureParenthesesStyle
 from flake8_pytest_style.visitors import FixturesVisitor
 
 
+# make the configs independent of the actual default
+_CONFIG_WITHOUT_PARENS = DEFAULT_CONFIG._replace(fixture_parentheses=False)
+_CONFIG_WITH_PARENS = DEFAULT_CONFIG._replace(fixture_parentheses=True)
+
+
 def test_ok_no_parameters():
     code = """
         import pytest
@@ -13,7 +18,7 @@ def test_ok_no_parameters():
         def my_fixture():
             return 0
     """
-    assert_not_error(FixturesVisitor, code, config=DEFAULT_CONFIG)
+    assert_not_error(FixturesVisitor, code, config=_CONFIG_WITH_PARENS)
 
 
 def test_ok_with_parameters():
@@ -24,7 +29,7 @@ def test_ok_with_parameters():
         def my_fixture():
             return 0
     """
-    assert_not_error(FixturesVisitor, code, config=DEFAULT_CONFIG)
+    assert_not_error(FixturesVisitor, code, config=_CONFIG_WITH_PARENS)
 
 
 def test_ok_without_parens():
@@ -35,8 +40,7 @@ def test_ok_without_parens():
         def my_fixture():
             return 0
     """
-    config = DEFAULT_CONFIG._replace(fixture_parentheses=False)
-    assert_not_error(FixturesVisitor, code, config=config)
+    assert_not_error(FixturesVisitor, code, config=_CONFIG_WITHOUT_PARENS)
 
 
 def test_error_without_parens():
@@ -51,7 +55,7 @@ def test_error_without_parens():
         FixturesVisitor,
         code,
         IncorrectFixtureParenthesesStyle,
-        config=DEFAULT_CONFIG,
+        config=_CONFIG_WITH_PARENS,
         expected_parens='()',
         actual_parens='',
     )
@@ -65,12 +69,11 @@ def test_error_with_parens():
         def my_fixture():
             return 0
     """
-    config = DEFAULT_CONFIG._replace(fixture_parentheses=False)
     assert_error(
         FixturesVisitor,
         code,
         IncorrectFixtureParenthesesStyle,
-        config=config,
+        config=_CONFIG_WITHOUT_PARENS,
         expected_parens='',
         actual_parens='()',
     )

--- a/tests/test_PT002_fixture_positional_args.py
+++ b/tests/test_PT002_fixture_positional_args.py
@@ -9,7 +9,7 @@ def test_ok_no_args():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def my_fixture():
             return 0
     """

--- a/tests/test_PT003_extraneous_scope_function.py
+++ b/tests/test_PT003_extraneous_scope_function.py
@@ -9,7 +9,7 @@ def test_ok_no_scope():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def my_fixture():
             return 0
     """

--- a/tests/test_PT004_missing_fixture_name_underscore.py
+++ b/tests/test_PT004_missing_fixture_name_underscore.py
@@ -9,7 +9,7 @@ def test_ok_simple():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def _patch_something(mocker):
             mocker.patch('some.thing')
     """
@@ -20,7 +20,7 @@ def test_ok_with_return():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def _patch_something(mocker):
             if something:
                 return
@@ -33,7 +33,7 @@ def test_ok_with_yield():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def _activate_context():
             with context:
                 yield
@@ -48,7 +48,7 @@ def test_ok_abstract_with_import_abc():
         import pytest
 
         class BaseTest:
-            @pytest.fixture()
+            @pytest.fixture
             @abc.abstractmethod
             def my_fixture():
                 raise NotImplementedError
@@ -63,7 +63,7 @@ def test_ok_abstract_with_from_import():
         import pytest
 
         class BaseTest:
-            @pytest.fixture()
+            @pytest.fixture
             @abstractmethod
             def my_fixture():
                 raise NotImplementedError
@@ -75,7 +75,7 @@ def test_ok_ignoring_yield_from():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def my_fixture():
             yield from some_generator()
     """
@@ -86,7 +86,7 @@ def test_error_simple():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def patch_something(mocker):
             mocker.patch('some.thing')
     """
@@ -103,7 +103,7 @@ def test_error_with_yield():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def activate_context():
             with context:
                 yield

--- a/tests/test_PT005_incorrect_fixture_name_underscore.py
+++ b/tests/test_PT005_incorrect_fixture_name_underscore.py
@@ -9,7 +9,7 @@ def test_ok_with_return():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def my_fixture(mocker):
             return 0
     """
@@ -20,7 +20,7 @@ def test_ok_with_yield():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def activate_context():
             with get_context() as context:
                 yield context
@@ -30,7 +30,7 @@ def test_ok_with_yield():
 
 def test_ok_nested_function():
     code = """
-        @pytest.fixture()
+        @pytest.fixture
         def _any_fixture(mocker):
             def nested_function():
                 return 1
@@ -47,7 +47,7 @@ def test_ok_abstract_with_import_abc():
         import pytest
 
         class BaseTest:
-            @pytest.fixture()
+            @pytest.fixture
             @abc.abstractmethod
             def _my_fixture():
                 return NotImplemented
@@ -62,7 +62,7 @@ def test_ok_abstract_with_from_import():
         import pytest
 
         class BaseTest:
-            @pytest.fixture()
+            @pytest.fixture
             @abstractmethod
             def _my_fixture():
                 return NotImplemented
@@ -74,7 +74,7 @@ def test_error_with_return():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def _my_fixture(mocker):
             return 0
     """
@@ -91,7 +91,7 @@ def test_error_with_yield():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def _activate_context():
             with get_context() as context:
                 yield context
@@ -109,7 +109,7 @@ def test_error_with_conditional_yield_from():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def _activate_context():
             if some_condition:
                 with get_context() as context:

--- a/tests/test_PT020_deprecated_yield_fixture.py
+++ b/tests/test_PT020_deprecated_yield_fixture.py
@@ -4,7 +4,6 @@ from flake8_pytest_style.config import DEFAULT_CONFIG
 from flake8_pytest_style.errors import DeprecatedYieldFixture
 from flake8_pytest_style.visitors import FixturesVisitor
 
-
 # make the configs independent of the actual default
 _CONFIG_WITHOUT_PARENS = DEFAULT_CONFIG._replace(fixture_parentheses=False)
 _CONFIG_WITH_PARENS = DEFAULT_CONFIG._replace(fixture_parentheses=True)
@@ -40,7 +39,9 @@ def test_error_without_parens():
         def my_fixture():
             return 0
     """
-    assert_error(FixturesVisitor, code, DeprecatedYieldFixture, config=_CONFIG_WITHOUT_PARENS)
+    assert_error(
+        FixturesVisitor, code, DeprecatedYieldFixture, config=_CONFIG_WITHOUT_PARENS
+    )
 
 
 def test_error_with_parens():
@@ -51,4 +52,6 @@ def test_error_with_parens():
         def my_fixture():
             return 0
     """
-    assert_error(FixturesVisitor, code, DeprecatedYieldFixture, config=_CONFIG_WITH_PARENS)
+    assert_error(
+        FixturesVisitor, code, DeprecatedYieldFixture, config=_CONFIG_WITH_PARENS
+    )

--- a/tests/test_PT020_deprecated_yield_fixture.py
+++ b/tests/test_PT020_deprecated_yield_fixture.py
@@ -5,6 +5,11 @@ from flake8_pytest_style.errors import DeprecatedYieldFixture
 from flake8_pytest_style.visitors import FixturesVisitor
 
 
+# make the configs independent of the actual default
+_CONFIG_WITHOUT_PARENS = DEFAULT_CONFIG._replace(fixture_parentheses=False)
+_CONFIG_WITH_PARENS = DEFAULT_CONFIG._replace(fixture_parentheses=True)
+
+
 def test_ok_no_parameters():
     code = """
         import pytest
@@ -13,7 +18,7 @@ def test_ok_no_parameters():
         def my_fixture():
             return 0
     """
-    assert_not_error(FixturesVisitor, code, config=DEFAULT_CONFIG)
+    assert_not_error(FixturesVisitor, code, config=_CONFIG_WITH_PARENS)
 
 
 def test_ok_without_parens():
@@ -24,22 +29,10 @@ def test_ok_without_parens():
         def my_fixture():
             return 0
     """
-    config = DEFAULT_CONFIG._replace(fixture_parentheses=False)
-    assert_not_error(FixturesVisitor, code, config=config)
+    assert_not_error(FixturesVisitor, code, config=_CONFIG_WITHOUT_PARENS)
 
 
 def test_error_without_parens():
-    code = """
-        import pytest
-
-        @pytest.yield_fixture()
-        def my_fixture():
-            return 0
-    """
-    assert_error(FixturesVisitor, code, DeprecatedYieldFixture, config=DEFAULT_CONFIG)
-
-
-def test_error_with_parens():
     code = """
         import pytest
 
@@ -47,5 +40,15 @@ def test_error_with_parens():
         def my_fixture():
             return 0
     """
-    config = DEFAULT_CONFIG._replace(fixture_parentheses=False)
-    assert_error(FixturesVisitor, code, DeprecatedYieldFixture, config=config)
+    assert_error(FixturesVisitor, code, DeprecatedYieldFixture, config=_CONFIG_WITHOUT_PARENS)
+
+
+def test_error_with_parens():
+    code = """
+        import pytest
+
+        @pytest.yield_fixture()
+        def my_fixture():
+            return 0
+    """
+    assert_error(FixturesVisitor, code, DeprecatedYieldFixture, config=_CONFIG_WITH_PARENS)

--- a/tests/test_PT021_fixture_finalizer_callback.py
+++ b/tests/test_PT021_fixture_finalizer_callback.py
@@ -9,7 +9,7 @@ def test_ok_return():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def my_fixture():
             return 0
     """
@@ -20,7 +20,7 @@ def test_ok_yield():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def my_fixture():
             resource = acquire_resource()
             yield resource
@@ -33,7 +33,7 @@ def test_ok_other_request():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def my_fixture():
             request = get_request()
             request.addfinalizer(finalizer)
@@ -54,7 +54,7 @@ def test_ok_other_function():
             request.addfinalizer(resource.release)
             return resource
 
-        @pytest.fixture()
+        @pytest.fixture
         def resource_factory(request):
             return functools.partial(create_resource, request=request)
     """
@@ -66,7 +66,7 @@ def test_ok_nested_function():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def resource_factory(request):
             def create_resource(arg) -> Resource:
                 resource = Resource(arg)
@@ -81,7 +81,7 @@ def test_error_return():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def my_fixture(request):
             resource = acquire_resource()
             request.addfinalizer(resource.release)
@@ -94,7 +94,7 @@ def test_error_yield():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def my_fixture(request):
             resource = acquire_resource()
             request.addfinalizer(resource.release)

--- a/tests/test_PT022_useless_yield_fixture.py
+++ b/tests/test_PT022_useless_yield_fixture.py
@@ -4,7 +4,7 @@ from flake8_pytest_style.config import DEFAULT_CONFIG
 from flake8_pytest_style.errors import UselessYieldFixture
 from flake8_pytest_style.visitors import FixturesVisitor
 
-# Skipping basic OK tests tests because we have A LOT of valid fixtures in other
+# Skipping basic OK tests because we have A LOT of valid fixtures in other
 # test files
 
 
@@ -12,7 +12,7 @@ def test_ok_complex_logic():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def my_fixture():
             if some_condition:
                 resource = acquire_resource()
@@ -28,7 +28,7 @@ def test_error():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         def my_fixture():
             resource = acquire_resource()
             yield resource

--- a/tests/test_PT023_incorrect_mark_parentheses_style.py
+++ b/tests/test_PT023_incorrect_mark_parentheses_style.py
@@ -5,7 +5,6 @@ from flake8_pytest_style.config import DEFAULT_CONFIG
 from flake8_pytest_style.errors import IncorrectMarkParenthesesStyle
 from flake8_pytest_style.visitors import MarksVisitor
 
-
 _CONFIG_WITHOUT_PARENS = DEFAULT_CONFIG._replace(mark_parentheses=False)
 _CONFIG_WITH_PARENS = DEFAULT_CONFIG._replace(mark_parentheses=True)
 

--- a/tests/test_PT023_incorrect_mark_parentheses_style.py
+++ b/tests/test_PT023_incorrect_mark_parentheses_style.py
@@ -5,6 +5,11 @@ from flake8_pytest_style.config import DEFAULT_CONFIG
 from flake8_pytest_style.errors import IncorrectMarkParenthesesStyle
 from flake8_pytest_style.visitors import MarksVisitor
 
+
+_CONFIG_WITHOUT_PARENS = DEFAULT_CONFIG._replace(mark_parentheses=False)
+_CONFIG_WITH_PARENS = DEFAULT_CONFIG._replace(mark_parentheses=True)
+
+
 SAMPLES_WITHOUT_PARENTHESES = [
     pytest.param(
         """
@@ -139,13 +144,12 @@ def test_ok_with_parameters_regardless_of_config(mark_parentheses: bool):
 
 @pytest.mark.parametrize('code', SAMPLES_WITHOUT_PARENTHESES)
 def test_ok_without_parens(code: str):
-    config = DEFAULT_CONFIG._replace(mark_parentheses=False)
-    assert_not_error(MarksVisitor, code, config=config)
+    assert_not_error(MarksVisitor, code, config=_CONFIG_WITHOUT_PARENS)
 
 
 @pytest.mark.parametrize('code', SAMPLES_WITH_PARENTHESES)
 def test_ok_with_parens(code: str):
-    assert_not_error(MarksVisitor, code, config=DEFAULT_CONFIG)
+    assert_not_error(MarksVisitor, code, config=_CONFIG_WITH_PARENS)
 
 
 @pytest.mark.parametrize('code', SAMPLES_WITHOUT_PARENTHESES)
@@ -154,7 +158,7 @@ def test_error_without_parens(code: str):
         MarksVisitor,
         code,
         IncorrectMarkParenthesesStyle,
-        config=DEFAULT_CONFIG,
+        config=_CONFIG_WITH_PARENS,
         mark_name='foo',
         expected_parens='()',
         actual_parens='',
@@ -163,12 +167,11 @@ def test_error_without_parens(code: str):
 
 @pytest.mark.parametrize('code', SAMPLES_WITH_PARENTHESES)
 def test_error_with_parens(code: str):
-    config = DEFAULT_CONFIG._replace(mark_parentheses=False)
     assert_error(
         MarksVisitor,
         code,
         IncorrectMarkParenthesesStyle,
-        config=config,
+        config=_CONFIG_WITHOUT_PARENS,
         mark_name='foo',
         expected_parens='',
         actual_parens='()',

--- a/tests/test_PT024_unncessary_asyncio_mark_on_fixture.py
+++ b/tests/test_PT024_unncessary_asyncio_mark_on_fixture.py
@@ -32,7 +32,7 @@ def test_error_before():
         import pytest
 
         @pytest.mark.asyncio()
-        @pytest.fixture()
+        @pytest.fixture
         async def my_fixture():
             return 0
     """
@@ -46,7 +46,7 @@ def test_error_before_no_parens():
         import pytest
 
         @pytest.mark.asyncio
-        @pytest.fixture()
+        @pytest.fixture
         async def my_fixture():
             return 0
     """
@@ -59,7 +59,7 @@ def test_error_after():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         @pytest.mark.asyncio()
         async def my_fixture():
             return 0
@@ -73,7 +73,7 @@ def test_error_after_no_parens():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         @pytest.mark.asyncio
         async def my_fixture():
             return 0

--- a/tests/test_PT025_erroneous_usefixtures_on_fixture.py
+++ b/tests/test_PT025_erroneous_usefixtures_on_fixture.py
@@ -21,7 +21,7 @@ def test_error_before():
         import pytest
 
         @pytest.mark.usefixtures('a')
-        @pytest.fixture()
+        @pytest.fixture
         def my_fixture():
             return 0
     """
@@ -37,7 +37,7 @@ def test_error_after():
     code = """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture
         @pytest.mark.usefixtures('a')
         def my_fixture():
             return 0

--- a/tests/test_PT026_usefixtures_without_parameters.py
+++ b/tests/test_PT026_usefixtures_without_parameters.py
@@ -24,7 +24,8 @@ def test_ok_another_mark_with_parens():
         def test_something():
             pass
     """
-    assert_not_error(MarksVisitor, code, config=DEFAULT_CONFIG)
+    config = DEFAULT_CONFIG._replace(mark_parentheses=True)
+    assert_not_error(MarksVisitor, code, config=config)
 
 
 def test_ok_another_mark_no_parens():
@@ -47,8 +48,9 @@ def test_error_with_parens():
         def test_something():
             pass
     """
+    config = DEFAULT_CONFIG._replace(mark_parentheses=True)
     assert_error(
-        MarksVisitor, code, UseFixturesWithoutParameters, config=DEFAULT_CONFIG
+        MarksVisitor, code, UseFixturesWithoutParameters, config=config
     )
 
 

--- a/tests/test_PT026_usefixtures_without_parameters.py
+++ b/tests/test_PT026_usefixtures_without_parameters.py
@@ -49,9 +49,7 @@ def test_error_with_parens():
             pass
     """
     config = DEFAULT_CONFIG._replace(mark_parentheses=True)
-    assert_error(
-        MarksVisitor, code, UseFixturesWithoutParameters, config=config
-    )
+    assert_error(MarksVisitor, code, UseFixturesWithoutParameters, config=config)
 
 
 def test_error_no_parens():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,7 @@ from flake8_pytest_style.config import (
 from flake8_pytest_style.plugin import PytestStylePlugin
 
 
-@pytest.fixture()
+@pytest.fixture
 def option_manager() -> OptionManager:
     manager = OptionManager(
         version=flake8.__version__,


### PR DESCRIPTION
Fixes #272 