### PR TITLE
fix: add pre-commit hook

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -15,6 +15,10 @@ replace = **Unreleased**
 	
 	**{new_version} - {now:%Y-%m-%d}**
 
+[bumpversion:file(pre-commit):README.md]
+search = - flake8-pytest-style=={current_version}
+replace = - flake8-pytest-style=={new_version}
+
 [bumpversion:file:flake8_pytest_style/plugin.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,0 @@
-- id: flake8-pytest-style
-  name: flake8-pytest-style
-  description: Check common style issues or inconsistencies with pytest-based tests
-  entry: flake8
-  language: python
-  types: [python]
-  additional_dependencies: [flake8>=7.3.0]
-  require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: flake8-pytest-style
+  name: flake8-pytest-style
+  description: Check common style issues or inconsistencies with pytest-based tests
+  entry: flake8
+  language: python
+  types: [python]
+  additional_dependencies: [flake8>=7.3.0]
+  require_serial: true

--- a/README.md
+++ b/README.md
@@ -64,6 +64,45 @@ The plugin has the following configuration options:
 * `pytest-mark-no-parentheses` &mdash; see [PT023]
 * `pytest-warns-require-match-for` &mdash; see [PT030]
 
+## Usage as a pre-commit hook
+
+This plugin is a [flake8](https://flake8.pycqa.org/) extension, so it runs
+through flake8 rather than as a standalone tool. There are two ways to use it
+with [pre-commit](https://pre-commit.com/).
+
+### Via the flake8 hook (recommended)
+
+Add the plugin as an `additional_dependencies` of the official flake8 hook.
+This keeps full control over which `PT` codes are enabled through your normal
+flake8 configuration:
+
+```yaml
+repos:
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-pytest-style==2.2.0
+```
+
+### Via this repository's hook
+
+This repository also exposes its own hook. It installs the plugin and runs
+flake8 for you:
+
+```yaml
+repos:
+  - repo: https://github.com/m-burst/flake8-pytest-style
+    rev: 2.2.0
+    hooks:
+      - id: flake8-pytest-style
+```
+
+Note that this still runs all installed flake8 checks (just flake8 + this
+plugin in an isolated environment); enable or disable individual `PT` codes
+via your flake8 config as usual.
+
 ## For developers
 
 ### Install deps and setup pre-commit hook

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-A `flake8` plugin checking common style issues or inconsistencies with `pytest`-based tests.
+A [`flake8`](https://flake8.pycqa.org/) plugin checking common style issues or inconsistencies with `pytest`-based tests.
 
 Currently the following errors are reported:
 
@@ -48,28 +48,27 @@ Currently the following errors are reported:
 | [PT030] | pytest.warns({warning}) is too broad, set the match parameter or use a more specific warning <br> (configurable by `pytest-warns-require-match-for`) |
 | [PT031] | pytest.warns() block should contain a single simple statement |
 
-## Installation
+## Installation and usage
 
-    pip install flake8-pytest-style
+### As a dependency
 
-## Configuration
+Install the plugin using the package manager of your choice, e.g.
 
-The plugin has the following configuration options:
+```bash
+uv add --group dev flake8-pytest-style
+# or
+poetry add --group dev flake8-pytest-style
+# or
+pip install flake8-pytest-style
+```
 
-* `pytest-fixture-no-parentheses` &mdash; see [PT001]
-* `pytest-parametrize-names-type` &mdash; see [PT006]
-* `pytest-parametrize-values-type` &mdash; see [PT007]
-* `pytest-parametrize-values-row-type` &mdash; see [PT007]
-* `pytest-raises-require-match-for` &mdash; see [PT011]
-* `pytest-mark-no-parentheses` &mdash; see [PT023]
-* `pytest-warns-require-match-for` &mdash; see [PT030]
+and then run `flake8` as you normally would.
 
-## Usage as a pre-commit hook
+### As a pre-commit hook
 
-This plugin is a [flake8](https://flake8.pycqa.org/) extension, so it runs
-through flake8 rather than as a standalone tool. To use it with
-[pre-commit](https://pre-commit.com/), add the plugin as an
-`additional_dependencies` of the official flake8 hook:
+The plugin is a `flake8` extension, not a standalone tool. To use it with
+[pre-commit](https://pre-commit.com/), add the plugin to the
+`additional_dependencies` section of the official `flake8` hook:
 
 ```yaml
 repos:
@@ -81,8 +80,19 @@ repos:
           - flake8-pytest-style==2.2.0
 ```
 
-This keeps full control over which `PT` codes are enabled through your normal
-flake8 configuration.
+## Configuration
+
+The plugin is configured via [`flake8` configuration](https://flake8.pycqa.org/en/latest/user/configuration.html)
+file and/or CLI options. Specific errors can be selected or ignored; 
+there are also the following plugin-specific configuration options:
+
+* `pytest-fixture-no-parentheses` &mdash; see [PT001]
+* `pytest-parametrize-names-type` &mdash; see [PT006]
+* `pytest-parametrize-values-type` &mdash; see [PT007]
+* `pytest-parametrize-values-row-type` &mdash; see [PT007]
+* `pytest-raises-require-match-for` &mdash; see [PT011]
+* `pytest-mark-no-parentheses` &mdash; see [PT023]
+* `pytest-warns-require-match-for` &mdash; see [PT030]
 
 ## For developers
 

--- a/README.md
+++ b/README.md
@@ -67,14 +67,9 @@ The plugin has the following configuration options:
 ## Usage as a pre-commit hook
 
 This plugin is a [flake8](https://flake8.pycqa.org/) extension, so it runs
-through flake8 rather than as a standalone tool. There are two ways to use it
-with [pre-commit](https://pre-commit.com/).
-
-### Via the flake8 hook (recommended)
-
-Add the plugin as an `additional_dependencies` of the official flake8 hook.
-This keeps full control over which `PT` codes are enabled through your normal
-flake8 configuration:
+through flake8 rather than as a standalone tool. To use it with
+[pre-commit](https://pre-commit.com/), add the plugin as an
+`additional_dependencies` of the official flake8 hook:
 
 ```yaml
 repos:
@@ -86,22 +81,8 @@ repos:
           - flake8-pytest-style==2.2.0
 ```
 
-### Via this repository's hook
-
-This repository also exposes its own hook. It installs the plugin and runs
-flake8 for you:
-
-```yaml
-repos:
-  - repo: https://github.com/m-burst/flake8-pytest-style
-    rev: 2.2.0
-    hooks:
-      - id: flake8-pytest-style
-```
-
-Note that this still runs all installed flake8 checks (just flake8 + this
-plugin in an isolated environment); enable or disable individual `PT` codes
-via your flake8 config as usual.
+This keeps full control over which `PT` codes are enabled through your normal
+flake8 configuration.
 
 ## For developers
 


### PR DESCRIPTION
  # Add pre-commit hook support

https://github.com/m-burst/flake8-pytest-style/issues/398

  ## Summary

Without .pre-commit-hooks.yaml, downstream repos couldn't reference it directly in their .pre-commit-config.yaml. This PR adds a hook definition and documents how to consume the plugin via pre-commit.

## Changes

  - .pre-commit-hooks.yaml (new): exposes a flake8-pytest-style hook.
  - README.md: new "Usage as a pre-commit hook" section covering both supported approaches.

## Testing

  Validated locally with pre-commit try-repo against a sample test file containing intentional violations:

# Pre-commit hook test output

Verification that the new `.pre-commit-hooks.yaml` works.

## Sample file

`/tmp/sample_test.py`:

```python
import pytest


@pytest.fixture()
def my_fixture():
    return 42


def test_something(my_fixture):
    with pytest.raises(Exception):
        raise ValueError("boom")
    assert my_fixture == 42
```

## Command

```
pre-commit try-repo . flake8-pytest-style --files /tmp/sample_test.py --verbose
```

## Output

```
===============================================================================
Using config:
===============================================================================
repos:
-   repo: .
    rev: d8caacfac18d79f98c76c2e0853e92919cde5288
    hooks:
    -   id: flake8-pytest-style
===============================================================================
flake8-pytest-style......................................................Failed
- hook id: flake8-pytest-style
- duration: 0.14s
- exit code: 1

../../../tmp/sample_test.py:4:2: PT001 use @pytest.fixture over @pytest.fixture()
@pytest.fixture()
 ^
../../../tmp/sample_test.py:10:10: PT011 pytest.raises(Exception) is too broad, set the match parameter or use a more specific exception
    with pytest.raises(Exception):
         ^
```

The hook correctly flagged **PT001** (fixture parentheses) and **PT011**
(overly broad `pytest.raises`), confirming the plugin runs as a pre-commit hook.